### PR TITLE
ignore unexported fields

### DIFF
--- a/ko.go
+++ b/ko.go
@@ -78,7 +78,12 @@ func validate(
 		var (
 			resourceField = resource.Field(index)
 			structField   = resourceStruct.Field(index)
+			fieldName     = string(structField.Name)
 		)
+
+		if fieldName[0] == strings.ToLower(fieldName)[0] {
+			continue
+		}
 
 		if reflect.DeepEqual(
 			resourceField.Interface(),

--- a/ko_test.go
+++ b/ko_test.go
@@ -170,6 +170,32 @@ b = true
 	test.Equal("aaa", resource.A)
 }
 
+func TestSkipUnexportedFields(t *testing.T) {
+	test := assert.New(t)
+
+	path := write(`
+a = true
+`)
+	defer os.Remove(path)
+
+	type config struct {
+		A bool
+
+		unexported bool
+	}
+
+	resource := config{}
+	test.NoError(
+		Load(path, &resource),
+	)
+
+	ko := config{}
+	ko.A = true
+	ko.unexported = false
+
+	test.Equal(ko, resource)
+}
+
 func write(data string) string {
 	file, err := ioutil.TempFile(os.TempDir(), "ko_")
 	if err != nil {


### PR DESCRIPTION
Without that fix ko will panic if struct contains unexported fields.