### PR TITLE
validate: skip required fields in optional structs

### DIFF
--- a/ko.go
+++ b/ko.go
@@ -169,6 +169,16 @@ func validate(
 		}
 
 		if resourceField.Kind() == reflect.Struct && resourceField.CanAddr() {
+			// Skip validation of zero-valued structs if they are not required
+			isZeroValue := reflect.DeepEqual(
+				resourceField.Interface(),
+				reflect.Zero(resourceField.Type()).Interface(),
+			)
+			if isZeroValue && !structFieldRequired {
+				// Skip validation for optional zero-valued structs
+				continue
+			}
+
 			err := validate(
 				resourceField.Addr().Interface(),
 				structFieldRequired,


### PR DESCRIPTION
When a struct is marked as required:"false", its nested required fields should not be validated if the struct itself is not provided in the configuration. Previously, the validation logic would always recurse into struct fields and validate their required fields, even when the parent struct was optional and had a zero value.

This caused configurations to fail validation when they omitted optional structs that contained required fields, even though the entire struct was meant to be optional.

Fix this by checking if a struct field has a zero value and is not required before recursing into its validation. This ensures that optional structs are truly optional - their nested required fields are only validated when the struct is actually provided in the configuration.

Add test cases to verify the fix handles all scenarios:
- Optional struct not provided (should pass)
- Optional struct partially provided (should fail on missing required fields)
- Optional struct fully provided (should pass)

Fixes validation of configurations where optional structs contain required nested fields.