### PR TITLE
ko: propagate optional requirement through nested struct validation

### DIFF
--- a/ko.go
+++ b/ko.go
@@ -181,7 +181,7 @@ func validate(
 
 			err := validate(
 				resourceField.Addr().Interface(),
-				structFieldRequired,
+				parentRequired && structFieldRequired,
 				push(prefix, getFieldKey(structField))...,
 			)
 			if err != nil {
@@ -243,7 +243,7 @@ func validate(
 				if field.Kind() == reflect.Struct {
 					err := validate(
 						field.Addr().Interface(),
-						structFieldRequired,
+						parentRequired && structFieldRequired,
 						push(
 							prefix,
 							fmt.Sprintf(
@@ -265,7 +265,7 @@ func validate(
 				if reflect.Indirect(reflect.ValueOf(field.Interface())).Kind() == reflect.Struct {
 					err := validate(
 						field.Interface(),
-						structFieldRequired,
+						parentRequired && structFieldRequired,
 						push(
 							prefix,
 							fmt.Sprintf(

--- a/ko_test.go
+++ b/ko_test.go
@@ -812,13 +812,12 @@ func TestOptionalStructWithRequiredFields(t *testing.T) {
 		test.Equal(8080, cfg.Port)
 	})
 
-	// Test 3: Config with auth but missing required fields should fail
-	t.Run("config with incomplete optional struct fails", func(t *testing.T) {
+	// Test 3: Config with auth but missing required fields should succeed
+	// because auth is optional, so its children inherit that optionality
+	t.Run("config with incomplete optional struct succeeds", func(t *testing.T) {
 		test := assert.New(t)
-		// testdata/incomplete-auth.yaml contains:
-		// port: 8080
-		// auth:
-		//   timeout: 30
+		// When parent struct is optional, children fields inherit optionality
+		// even if marked as required
 		path := write(`port: 8080
 auth:
   timeout: 30`)
@@ -826,8 +825,9 @@ auth:
 
 		var cfg Config
 		err := Load(path, &cfg, yaml.Unmarshal)
-		test.Error(err)
-		test.Contains(err.Error(), "auth.credentials")
+		test.NoError(err) // Should succeed - auth is optional so its fields are too
+		test.Equal(8080, cfg.Port)
+		test.Equal(30, cfg.Auth.Timeout)
 	})
 
 	// Test 4: Complete config should succeed


### PR DESCRIPTION
Fix validation logic where optional parent structs with required child fields incorrectly validated those children as required, breaking the optional chain inheritance.

When a struct field is marked as required="false" but contains nested fields marked as required="true", the validation would fail if those nested fields were missing, even though the parent was optional.

For example, given:
  type Config struct {
      Database DBConfig `yaml:"database" required:"false"`
  }

  type DBConfig struct {
      Credentials DBCredentials `yaml:"credentials" required:"true"`
  }

A config with database present but credentials missing would incorrectly fail validation, despite database being optional.

Change validate() to pass (parentRequired && structFieldRequired) instead of just structFieldRequired when recursing into nested structures. This ensures that if any ancestor in the chain is optional, all descendants inherit that optionality for validation purposes.

Update TestOptionalStructWithRequiredFields to verify the corrected behavior: partial specification of optional structs should succeed rather than fail on missing required children.